### PR TITLE
Added basic ACL support

### DIFF
--- a/modules/lumble/client/channel.lua
+++ b/modules/lumble/client/channel.lua
@@ -200,4 +200,11 @@ function channel:hasPermission(flag)
 	return self.client:hasPermission(self, flag)
 end
 
+function channel:requestACL()
+	local query = packet.new("ACL")
+	query:set("channel_id", self.channel_id)
+	query:set("query", true)
+	self:sendTCP(query)
+end
+
 return channel

--- a/modules/lumble/client/init.lua
+++ b/modules/lumble/client/init.lua
@@ -820,7 +820,8 @@ function client:onPermissionDenied(packet)
 end
 
 function client:onACL(packet)
-	self:hookCall("OnACL")
+	local event = event.new(self, packet, true)
+	self:hookCall("OnACL", event)
 end
 
 function client:onQueryUsers(packet)
@@ -975,6 +976,14 @@ end
 function client:requestUserList()
 	local msg = packet.new("UserList")
 	self:sendTCP(msg)
+end
+
+function client:requestACL(channel_id)
+	local channel_id = channel_id or 0 --default to root channel
+	local query = packet.new(13, proto.ACL())
+	query:set("channel_id", channel_id)
+	query:set("query", true)
+	self:sendTCP(query)
 end
 
 local COMMAND = {}

--- a/modules/lumble/client/init.lua
+++ b/modules/lumble/client/init.lua
@@ -980,7 +980,7 @@ end
 
 function client:requestACL(channel_id)
 	local channel_id = channel_id or 0 --default to root channel
-	local query = packet.new(13, proto.ACL())
+	local query = packet.new("ACL")
 	query:set("channel_id", channel_id)
 	query:set("query", true)
 	self:sendTCP(query)

--- a/modules/lumble/event.lua
+++ b/modules/lumble/event.lua
@@ -27,11 +27,16 @@ function event.new(instance, packet, all)
 			else
 				event["channel"] = instance:getChannel(value)
 			end
+		elseif name == "groups" then
+			local g_dict = {}
+			for _,v in ipairs(value) do
+				g_dict[v.name] = v
+			end
+			event["groups"] = g_dict
 		elseif all then
 			event[name] = value
 		end
 	end
-
 	return event
 end
 


### PR DESCRIPTION
Use client:requestACL(channel_id) and the OnACL hook.
Rudimentary changes in event.lua will convert ACL groups array into a table (dictionary).